### PR TITLE
unix sock fan monitor + config file support

### DIFF
--- a/package/kvmd-fan/kvmd-fan.py
+++ b/package/kvmd-fan/kvmd-fan.py
@@ -3,12 +3,45 @@
 
 import RPi.GPIO
 import time
+from http.server import BaseHTTPRequestHandler
+from socketserver import UnixStreamServer
+import os
+from pwd import getpwnam
+import threading
+import argparse
+import configparser
+
+parser = argparse.ArgumentParser(
+                    prog='kvmd-fan',
+                    description='A small fan controller daemon')
+parser.add_argument('-c', '--config')
+args = parser.parse_args()
+
+config = configparser.ConfigParser()
+config['gpio'] = {'pin': '12'}
+config['temp'] = {'min': '60', 'max': '65'}
+config['speed'] = {'idle': '0'}
+config['server'] = {'unix': '/run/kvmd/fan.sock', 'rm': '1', 'unix_mode': '666'}
+
+config.read(args.config or '/etc/kvmd/fan.ini')
+
+for section, value in config.items():
+	print(f"[{section}]")
+	for key, value in value.items():
+	    print(f"{key}: {value}")
 
 #settings
-fan_gpio=12 # Fan GPIO pin number (default: 12)
-idle_speed = 0 # Fan speed when under min_temp(IDLE) (min: 0, max: 100)
-min_temp = 60 # Fan starting temperature 
-max_temp = 65 # Fan max speed temperature (max: 65)
+fan_gpio= config.getint('gpio', 'pin') # Fan GPIO pin number (default: 12)
+idle_speed = config.getint('speed', "idle") # Fan speed when under min_temp(IDLE) (min: 0, max: 100)
+min_temp = config.getfloat('temp', 'min') # Fan starting temperature 
+max_temp = config.getfloat('temp', 'max') # Fan max speed temperature (max: 65)
+
+VERSION = "0.1"
+socket_path = config.get('server', 'unix')
+
+# Remove existing socket file if it exists
+if os.path.exists(socket_path) and config.get('server', 'rm') == '1':
+    os.remove(socket_path)
 
 #define GPIO
 RPi.GPIO.setwarnings(False)
@@ -16,6 +49,49 @@ RPi.GPIO.setmode(RPi.GPIO.BCM)
 RPi.GPIO.setup(fan_gpio, RPi.GPIO.OUT)
 pwm = RPi.GPIO.PWM(fan_gpio,100)
 running = False
+cpu_temp = 0.0
+fan_speed = 0.0
+
+class Handler(BaseHTTPRequestHandler):
+	def do_GET(self):
+		content = "Stub"
+		content_type = "text/plain"
+		status = 200
+
+		if self.path == '/':
+			content_type = "application/json"
+			content = f'{{"ok": true, "result": {{"version": "{VERSION}"}}}}\n'
+		elif self.path == '/state':
+			content_type = "application/json"
+			content = ( '{"ok": true, "result": {'
+					 f'"service": {{"now_ts": 0.01}},'
+					f' "temp": {{"real": {cpu_temp:.2f}, "fixed": {cpu_temp:.2f}}},'
+					f' "fan": {{"speed": {fan_speed:.2f}, "pwm": 0, "ok": true, "last_fail_ts": -1}},'
+					 ' "hall": {"available": false, "rpm": 0}'
+					 '}}\n' )
+		else:
+			status = 404
+			content = "Not Found\n"
+
+		self.send_response_only(status)
+		self.send_header('Content-type', content_type)
+		self.end_headers()
+		self.wfile.write(bytes(content, "utf-8"))
+
+class UnixSocketHttpServer(UnixStreamServer):
+    def get_request(self):
+        request, client_address = super(UnixSocketHttpServer, self).get_request()
+        return (request, ["local", 0])
+
+def start_server():
+	server = UnixSocketHttpServer(socket_path, Handler)
+	uid = getpwnam("kvmd").pw_uid
+	gid = getpwnam("kvmd").pw_gid
+	os.chown(socket_path,uid,gid)
+	os.chmod(socket_path,config.getint('server', 'unix_mode'))
+	server.serve_forever()
+
+threading.Thread(target=start_server).start()
 
 #running code
 try:
@@ -35,11 +111,13 @@ try:
 				temp_speed = int((cpu_temp - min_temp) / (max_temp - min_temp) * 100) # set 0~100% for min and max temp ranges
 				set_speed = min(max(idle_speed, temp_speed), 100) # make speed not over 100 
 			print("set_speed:",set_speed,"%") 
+			fan_speed = set_speed
 			pwm.ChangeDutyCycle(set_speed)
 		else :
 			if(running):
 				running = False
 				pwm.stop()
+				fan_speed = 0
 				print("PWM_Stop")
 
 		time.sleep(5)
@@ -47,3 +125,4 @@ try:
 except KeyboardInterrupt:
 		pass
 pwm.stop()
+os.remove(socket_path)

--- a/package/kvmd-fan/kvmd-fan.py
+++ b/package/kvmd-fan/kvmd-fan.py
@@ -36,6 +36,9 @@ idle_speed = config.getint('speed', "idle") # Fan speed when under min_temp(IDLE
 min_temp = config.getfloat('temp', 'min') # Fan starting temperature 
 max_temp = config.getfloat('temp', 'max') # Fan max speed temperature (max: 65)
 
+print("Min Temp:",min_temp)
+print("Max Temp:",max_temp)
+
 VERSION = "0.1"
 socket_path = config.get('server', 'unix')
 

--- a/package/kvmd-fan/kvmd-fan.service
+++ b/package/kvmd-fan/kvmd-fan.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=always
 RestartSec=3
 EnvironmentFile=-/etc/conf.d/kvmd-fan
-ExecStart=/usr/bin/kvmd-fan --config=?/etc/kvmd/fan.ini $KVMD_FAN_ARGS
+ExecStart=/usr/bin/kvmd-fan --config=/etc/kvmd/fan.ini $KVMD_FAN_ARGS
 TimeoutStopSec=3
 
 [Install]


### PR DESCRIPTION
no need to [disable the fan indicator](https://wiki.blicube.com/blikvm/en/modify_pikvm_image/#fan-config) in the base pikvm image anymore

run the daemon and run `curl --unix-socket /run/kvmd/fan.sock http://local/state` to check the state from the socket

base image shows the Fan status too:
![image](https://github.com/user-attachments/assets/51fa5dbc-db05-4630-ba6c-6f8ebbd753d2)
